### PR TITLE
:bug: dont update risk when AI_RESPONSE event

### DIFF
--- a/blueprints/event.py
+++ b/blueprints/event.py
@@ -95,7 +95,7 @@ class UpdateEvent(MethodView):
     def post(self, incident_repo: IncidentRepository = Provide[Container.incident_repo]) -> Response:
         data = load_event_data()
 
-        if data.history[-1].action != Action.CLOSED:
+        if data.history[-1].action != Action.CLOSED and data.history[-1].action != Action.AI_RESPONSE:
             new_risk = self.set_risk(history=data.history)
             body = IncidentRiskUpdateBody(risk=new_risk)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced logic for updating incident risk based on the last action in the event history, preventing updates if the last action was either `CLOSED` or an `AI_RESPONSE`. 

- **Bug Fixes**
	- Improved control flow to ensure appropriate risk updates are executed based on specific conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->